### PR TITLE
chore: Update Cloudflare Worker URL to custom domain (gohk.xyz)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -48,7 +48,7 @@ npm run deploy
 This will:
 - Build and bundle your TypeScript code
 - Upload to Cloudflare Workers
-- Deploy to: `https://trmnl-google-photos.hk-c91.workers.dev`
+- Deploy to: `https://trmnl-google-photos.gohk.xyz`
 
 ### Expected Output
 
@@ -60,7 +60,7 @@ Your worker has access to the following bindings:
 Total Upload: XX.XX KiB / gzip: XX.XX KiB
 Uploaded trmnl-google-photos (X.XX sec)
 Published trmnl-google-photos (X.XX sec)
-  https://trmnl-google-photos.hk-c91.workers.dev
+  https://trmnl-google-photos.gohk.xyz
 Current Deployment ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 ```
 
@@ -70,10 +70,10 @@ Test the deployed worker:
 
 ```bash
 # Test root endpoint
-curl https://trmnl-google-photos.hk-c91.workers.dev/
+curl https://trmnl-google-photos.gohk.xyz/
 
 # Test health endpoint
-curl https://trmnl-google-photos.hk-c91.workers.dev/health
+curl https://trmnl-google-photos.gohk.xyz/health
 ```
 
 Expected response:
@@ -110,7 +110,7 @@ Add your account ID to `wrangler.toml` (see Step 2).
 
 ### Subdomain already taken
 
-If `trmnl-google-photos.hk-c91.workers.dev` is taken, you can:
+If `trmnl-google-photos.gohk.xyz` is taken, you can:
 
 1. Choose a different subdomain in `wrangler.toml`:
    ```toml

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -51,7 +51,7 @@ curl http://localhost:8787/
 
 3. Your worker is live at:
    ```
-   https://trmnl-google-photos.hk-c91.workers.dev
+   https://trmnl-google-photos.gohk.xyz
    ```
 
 ## 📚 Available Commands

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,7 +97,7 @@ The TRMNL Google Photos Plugin is a **stateless, privacy-first** system that dis
 
 ### 2. Cloudflare Worker (Core Backend)
 
-**Location**: `https://trmnl-google-photos.hk-c91.workers.dev`
+**Location**: `https://trmnl-google-photos.gohk.xyz`
 
 **Framework**: Hono (lightweight web framework)
 
@@ -210,7 +210,7 @@ The TRMNL Google Photos Plugin is a **stateless, privacy-first** system that dis
 
 ```
 1. TRMNL Platform → Cloudflare Worker
-   GET https://trmnl-google-photos.hk-c91.workers.dev/api/photo?album_url=https://photos.app.goo.gl/ABC123
+   GET https://trmnl-google-photos.gohk.xyz/api/photo?album_url=https://photos.app.goo.gl/ABC123
    
    Query Parameters:
    - album_url: Google Photos shared album URL (from form field)
@@ -346,7 +346,7 @@ The TRMNL Google Photos Plugin is a **stateless, privacy-first** system that dis
 │                                                         │
 │  ┌──────────────────────────────────────────────────┐ │
 │  │   Worker: trmnl-google-photos                    │ │
-│  │   URL: trmnl-google-photos.hk-c91.workers.dev   │ │
+│  │   URL: trmnl-google-photos.gohk.xyz   │ │
 │  │   Version: Latest (auto-deployed)                │ │
 │  └──────────────────────────────────────────────────┘ │
 │                                                         │
@@ -452,7 +452,7 @@ Planned GitHub Actions workflow:
 **TRMNL Integration** (`settings.yml`):
 ```yaml
 strategy: polling
-polling_url: https://trmnl-google-photos.hk-c91.workers.dev/api/photo?album_url={{ shared_album_url }}
+polling_url: https://trmnl-google-photos.gohk.xyz/api/photo?album_url={{ shared_album_url }}
 refresh_frequency: 60  # minutes (1 hour)
 ```
 

--- a/docs/ARCHITECTURE_CHANGE.md
+++ b/docs/ARCHITECTURE_CHANGE.md
@@ -76,7 +76,7 @@ Response: JSON { photo_url, caption, album_name, photo_count, timestamp }
 **Before**:
 ```yaml
 strategy: webhook
-markup_webhook_url: https://trmnl-google-photos.hk-c91.workers.dev/markup
+markup_webhook_url: https://trmnl-google-photos.gohk.xyz/markup
 private_variables:
   - name: shared_album_url
     type: string
@@ -85,7 +85,7 @@ private_variables:
 **After**:
 ```yaml
 strategy: polling
-polling_url: https://trmnl-google-photos.hk-c91.workers.dev/api/photo?album_url={{ shared_album_url }}
+polling_url: https://trmnl-google-photos.gohk.xyz/api/photo?album_url={{ shared_album_url }}
 polling_verb: GET
 form_fields:
   - name: shared_album_url

--- a/docs/FOLLOW_UP_TASKS.md
+++ b/docs/FOLLOW_UP_TASKS.md
@@ -17,7 +17,7 @@ This document outlines the remaining tasks for the **stateless Cloudflare Worker
 ### Issue 2: Set Up Cloudflare Worker Infrastructure ✅
 **Status**: COMPLETE  
 **Date Completed**: January 18, 2026  
-**Deployed**: Production at https://trmnl-google-photos.hk-c91.workers.dev
+**Deployed**: Production at https://trmnl-google-photos.gohk.xyz
 
 **Achievements**:
 - ✅ Cloudflare Workers project initialized with Wrangler CLI
@@ -43,7 +43,7 @@ This document outlines the remaining tasks for the **stateless Cloudflare Worker
 ### Issue 4: Build `/api/photo` JSON Endpoint ✅
 **Status**: COMPLETE  
 **Date Completed**: January 18, 2026  
-**Deployed**: Production at https://trmnl-google-photos.hk-c91.workers.dev/api/photo
+**Deployed**: Production at https://trmnl-google-photos.gohk.xyz/api/photo
 
 **Achievements**:
 - ✅ GET `/api/photo` endpoint created in Hono

--- a/docs/ISSUE_2_COMPLETE.md
+++ b/docs/ISSUE_2_COMPLETE.md
@@ -179,7 +179,7 @@ The worker is ready for deployment. To deploy:
 
 3. **Verify deployment:**
    ```bash
-   curl https://trmnl-google-photos.hk-c91.workers.dev/
+   curl https://trmnl-google-photos.gohk.xyz/
    ```
 
 See [DEPLOYMENT.md](DEPLOYMENT.md) for detailed instructions.
@@ -230,7 +230,7 @@ The infrastructure is complete and ready for feature implementation:
 ## Notes
 
 - Deployment to Cloudflare requires authentication and will be done by the repository owner
-- The worker name in `wrangler.toml` is set to `trmnl-google-photos` which will deploy to `trmnl-google-photos.hk-c91.workers.dev`
+- The worker name in `wrangler.toml` is set to `trmnl-google-photos` which will deploy to `trmnl-google-photos.gohk.xyz`
 - Development environment is configured with name `trmnl-google-photos-dev`
 - KV namespace bindings are commented out in `wrangler.toml` and will be enabled when caching is implemented
 

--- a/docs/ISSUE_4_COMPLETE.md
+++ b/docs/ISSUE_4_COMPLETE.md
@@ -207,7 +207,7 @@ As per `docs/FOLLOW_UP_TASKS.md`:
    - Optimize cold start performance
 
 3. **Deployment to Production**
-   - Deploy to `trmnl-google-photos.hk-c91.workers.dev`
+   - Deploy to `trmnl-google-photos.gohk.xyz`
    - Test in production environment
    - Monitor performance and errors
    - Set up Cloudflare Workers Analytics

--- a/docs/MARKUP_ENDPOINT.md
+++ b/docs/MARKUP_ENDPOINT.md
@@ -255,7 +255,7 @@ curl -X POST http://localhost:8787/markup \
 ### Using JavaScript
 
 ```javascript
-const response = await fetch('https://trmnl-google-photos.hk-c91.workers.dev/markup', {
+const response = await fetch('https://trmnl-google-photos.gohk.xyz/markup', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',

--- a/index.html
+++ b/index.html
@@ -336,7 +336,7 @@
     </div>
 
     <script>
-        const API_URL = 'https://trmnl-google-photos.hk-c91.workers.dev/api/photo';
+        const API_URL = 'https://trmnl-google-photos.gohk.xyz/api/photo';
         
         function useExampleUrl() {
             document.getElementById('albumUrl').value = 'https://photos.app.goo.gl/FB8ErkX2wJAQkJzV8';

--- a/scripts/test-load.js
+++ b/scripts/test-load.js
@@ -16,7 +16,7 @@
  * 
  * Example:
  *   node scripts/test-load.js http://localhost:8787 50
- *   node scripts/test-load.js https://trmnl-google-photos.hk-c91.workers.dev 100
+ *   node scripts/test-load.js https://trmnl-google-photos.gohk.xyz 100
  */
 
 import { performance } from 'node:perf_hooks';

--- a/settings.yml
+++ b/settings.yml
@@ -9,7 +9,7 @@ strategy: polling  # TRMNL polls Cloudflare Worker for JSON photo data
 refresh_frequency: 3600  # 1 hour (will fetch new random photo hourly)
 
 # Polling URL - TRMNL will call this endpoint with form field values
-polling_url: https://trmnl-google-photos.hk-c91.workers.dev/api/photo?album_url={{ shared_album_url }}
+polling_url: https://trmnl-google-photos.gohk.xyz/api/photo?album_url={{ shared_album_url }}
 polling_verb: GET
 polling_headers: ""  # No custom headers needed
 

--- a/src/README.md
+++ b/src/README.md
@@ -7,7 +7,7 @@ This directory contains the Cloudflare Worker implementation for the TRMNL Googl
 - **Framework**: Hono (lightweight web framework for Cloudflare Workers)
 - **Language**: TypeScript
 - **Runtime**: Cloudflare Workers
-- **Deployment**: `trmnl-google-photos.hk-c91.workers.dev`
+- **Deployment**: `trmnl-google-photos.gohk.xyz`
 
 ## Project Structure
 
@@ -134,7 +134,7 @@ npm test
 npm run deploy
 ```
 
-This deploys to: `https://trmnl-google-photos.hk-c91.workers.dev`
+This deploys to: `https://trmnl-google-photos.gohk.xyz`
 
 ### Deploy to Development Environment
 


### PR DESCRIPTION
## Summary

Update all references from Cloudflare Workers default URL to custom domain for cleaner branding and professional appearance.

## Changes

**Old URL:** `trmnl-google-photos.hk-c91.workers.dev`  
**New URL:** `trmnl-google-photos.gohk.xyz`

### Files Updated (12 files)

1. **Configuration**
   - `settings.yml` - Updated polling_url

2. **Demo/Frontend**
   - `index.html` - Updated API_URL constant

3. **Documentation**
   - `DEPLOYMENT.md` - Updated deployment URLs
   - `QUICKSTART.md` - Updated quick start URLs
   - `src/README.md` - Updated deployment references
   - `docs/ARCHITECTURE.md` - Updated architecture diagrams and URLs
   - `docs/ARCHITECTURE_CHANGE.md` - Updated example URLs
   - `docs/FOLLOW_UP_TASKS.md` - Updated deployed URLs
   - `docs/ISSUE_2_COMPLETE.md` - Updated worker URLs
   - `docs/ISSUE_4_COMPLETE.md` - Updated deployment URLs
   - `docs/MARKUP_ENDPOINT.md` - Updated example fetch URLs

4. **Scripts**
   - `scripts/test-load.js` - Updated test URL examples

## Technical Details

- Global find/replace performed on: `*.md`, `*.yml`, `*.html`, `*.js`, `*.ts`
- No functional changes - purely URL updates
- Custom domain already configured in Cloudflare
- API endpoints remain the same structure

## Testing

- ✅ Verified settings.yml has correct polling URL
- ✅ Verified index.html API_URL is updated
- ✅ All documentation references updated
- ✅ No broken links introduced

## Benefits

- Cleaner, more professional URL
- Branded domain (gohk.xyz)
- Shorter and easier to remember
- Maintains all existing functionality