### PR TITLE
Fix duplicate API_URL declaration breaking health check

### DIFF
--- a/index.html
+++ b/index.html
@@ -584,8 +584,6 @@
             checkServiceStatus();
         });
         
-        const API_URL = 'https://trmnl-google-photos.gohk.xyz/api/photo';
-        
         function useExampleUrl() {
             console.log('[UI] Using example album URL');
             document.getElementById('albumUrl').value = 'https://photos.app.goo.gl/FB8ErkX2wJAQkJzV8';


### PR DESCRIPTION
## Problem
The health status badge was stuck on "🟡 Checking..." and never updating to online/offline status.

JavaScript console showed error:
```
Uncaught SyntaxError: Identifier 'API_URL' has already been declared
```

## Root Cause
Duplicate `const API_URL` declaration on line 275 - the constant was already declared at line 214. This syntax error crashed the entire script before the health check could complete.

## Solution
- Removed the duplicate `const API_URL` declaration
- Health status badge now properly transitions from checking → online/offline

## Testing
- ✅ No more JavaScript syntax errors in console
- ✅ Health check executes on page load
- ✅ Status badge updates correctly to show service status
- ✅ All other functionality (fetch photo data, preview templates) works as expected

## Files Changed
- `index.html` - Removed duplicate API_URL constant declaration