### PR TITLE
chore: Update demo album URL to ENK6C44K85QgVHPH8

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,7 @@ This is a TRMNL plugin that displays random photos from Google Photos shared alb
 - ✅ All 65 tests passing
 - ✅ Production deployment at `trmnl-google-photos.gohk.xyz`
 
-**Demo Album**: For testing and examples, use `https://photos.app.goo.gl/FB8ErkX2wJAQkJzV8`
+**Demo Album**: For testing and examples, use `https://photos.app.goo.gl/ENK6C44K85QgVHPH8`
 
 ## Getting Started
 

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -78,7 +78,7 @@ Host: trmnl-google-photos.workers.dev
 **Headers:**
 
 ```http
-GET /api/photo?album_url=https://photos.app.goo.gl/FB8ErkX2wJAQkJzV8 HTTP/1.1
+GET /api/photo?album_url=https://photos.app.goo.gl/ENK6C44K85QgVHPH8 HTTP/1.1
 Host: trmnl-google-photos.gohk.xyz
 ```
 
@@ -257,7 +257,7 @@ X-Request-ID: a1b2c3d4
 ### Example 1: Basic Request (JSON API)
 
 ```bash
-curl "https://trmnl-google-photos.gohk.xyz/api/photo?album_url=https://photos.app.goo.gl/FB8ErkX2wJAQkJzV8"
+curl "https://trmnl-google-photos.gohk.xyz/api/photo?album_url=https://photos.app.goo.gl/ENK6C44K85QgVHPH8"
 ```
 
 **Response:**
@@ -283,7 +283,7 @@ curl "https://trmnl-google-photos.gohk.xyz/api/photo?album_url=https://photos.go
 
 ```bash
 # Start local dev server first: npm run dev
-curl "http://localhost:8787/api/photo?album_url=https://photos.app.goo.gl/FB8ErkX2wJAQkJzV8"
+curl "http://localhost:8787/api/photo?album_url=https://photos.app.goo.gl/ENK6C44K85QgVHPH8"
 ```
 
 ---

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -35,7 +35,7 @@ curl http://localhost:8787/
 # }
 
 # Test the photo endpoint
-curl "http://localhost:8787/api/photo?album_url=https://photos.app.goo.gl/FB8ErkX2wJAQkJzV8"
+curl "http://localhost:8787/api/photo?album_url=https://photos.app.goo.gl/ENK6C44K85QgVHPH8"
 ```
 
 ## 🌐 Deploy to Cloudflare

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -181,7 +181,7 @@ Integration tests validate the library integration with real albums:
 
 #### Test Album
 
-- **URL**: `https://photos.app.goo.gl/FB8ErkX2wJAQkJzV8` (demo album)
+- **URL**: `https://photos.app.goo.gl/ENK6C44K85QgVHPH8` (demo album)
 - **Expected**: Array of ImageInfo objects
 - **Status**: ✅ Working with production deployment
 
@@ -228,7 +228,7 @@ To test locally:
 npm run dev
 
 # Test endpoint
-curl "http://localhost:8787/api/photo?album_url=https://photos.app.goo.gl/FB8ErkX2wJAQkJzV8"
+curl "http://localhost:8787/api/photo?album_url=https://photos.app.goo.gl/ENK6C44K85QgVHPH8"
 ```
 
 ## Error Handling Tests

--- a/index.html
+++ b/index.html
@@ -594,7 +594,7 @@
                     type="text" 
                     id="albumUrl" 
                     placeholder="Paste your Google Photos album URL (photos.app.goo.gl/...)" 
-                    value="https://photos.app.goo.gl/FB8ErkX2wJAQkJzV8"
+                    value="https://photos.app.goo.gl/ENK6C44K85QgVHPH8"
                 >
                 <button onclick="fetchPhotoData()" id="fetchBtn">🔄 Fetch Photo Data</button>
             </div>
@@ -784,7 +784,7 @@
         
         function useExampleUrl() {
             console.log('[UI] Using example album URL');
-            document.getElementById('albumUrl').value = 'https://photos.app.goo.gl/FB8ErkX2wJAQkJzV8';
+            document.getElementById('albumUrl').value = 'https://photos.app.goo.gl/ENK6C44K85QgVHPH8';
         }
         
         async function fetchPhotoData() {

--- a/src/README.md
+++ b/src/README.md
@@ -80,7 +80,7 @@ curl http://localhost:8787/
 curl http://localhost:8787/health
 
 # Test /api/photo with valid album
-curl "http://localhost:8787/api/photo?album_url=https://photos.app.goo.gl/FB8ErkX2wJAQkJzV8"
+curl "http://localhost:8787/api/photo?album_url=https://photos.app.goo.gl/ENK6C44K85QgVHPH8"
 ```
 
 ### Type Checking

--- a/src/services/README_CACHE.md
+++ b/src/services/README_CACHE.md
@@ -258,10 +258,10 @@ Test with production KV namespace:
 
 ```bash
 # Test cache miss (first request to an album)
-curl "https://trmnl-google-photos.gohk.xyz/api/photo?album_url=https://photos.app.goo.gl/FB8ErkX2wJAQkJzV8"
+curl "https://trmnl-google-photos.gohk.xyz/api/photo?album_url=https://photos.app.goo.gl/ENK6C44K85QgVHPH8"
 
 # Test cache hit (within 1 hour, same album)
-curl "https://trmnl-google-photos.gohk.xyz/api/photo?album_url=https://photos.app.goo.gl/FB8ErkX2wJAQkJzV8"
+curl "https://trmnl-google-photos.gohk.xyz/api/photo?album_url=https://photos.app.goo.gl/ENK6C44K85QgVHPH8"
 ```
 
 ## Cloudflare Limits

--- a/src/tests/test-load.ts
+++ b/src/tests/test-load.ts
@@ -56,7 +56,7 @@ interface SuccessCriteria {
 // Configuration
 const DEFAULT_WORKER_URL = 'http://localhost:8787';
 const DEFAULT_NUM_REQUESTS = 50;
-const VALID_ALBUM_URL = 'https://photos.app.goo.gl/FB8ErkX2wJAQkJzV8';
+const VALID_ALBUM_URL = 'https://photos.app.goo.gl/ENK6C44K85QgVHPH8';
 
 // Parse command line arguments
 const workerUrl = process.argv[2] || DEFAULT_WORKER_URL;

--- a/src/tests/test-performance.ts
+++ b/src/tests/test-performance.ts
@@ -126,7 +126,7 @@ async function testUrlParsing(): Promise<MeasurementResult<unknown>[]> {
   const { parseAlbumUrl } = await import(join(projectRoot, 'src', 'lib', 'url-parser'));
 
   const testUrls: string[] = [
-    'https://photos.app.goo.gl/FB8ErkX2wJAQkJzV8',
+    'https://photos.app.goo.gl/ENK6C44K85QgVHPH8',
     'https://photos.google.com/share/AF1QipMZNuJ5JH6n3yF',
     'https://photos.google.com/share/AF1QipMZNuJ5JH6n3yF?key=value',
   ];


### PR DESCRIPTION
## Summary
Updates the demo album URL throughout the project from the old URL to the new official demo album.

## Changes
Replaced `https://photos.app.goo.gl/FB8ErkX2wJAQkJzV8` with `https://photos.app.goo.gl/ENK6C44K85QgVHPH8` in:

### Documentation (5 files)
- ✅ `.github/copilot-instructions.md` - Demo album reference
- ✅ `docs/API_DOCUMENTATION.md` - Example requests (3 occurrences)
- ✅ `docs/TESTING.md` - Test instructions (2 occurrences)
- ✅ `docs/QUICKSTART.md` - Getting started guide
- ✅ `src/services/README_CACHE.md` - Cache testing examples (2 occurrences)

### Source Code (2 files)
- ✅ `src/README.md` - Development curl example
- ✅ `index.html` - Default album URL input field + JavaScript (2 occurrences)

### Tests (2 files)
- ✅ `src/tests/test-performance.ts` - Performance test URL
- ✅ `src/tests/test-load.ts` - Load test constant

**Total: 14 occurrences updated across 9 files**

## Why This Change
The new demo album URL (`ENK6C44K85QgVHPH8`) is the official demo album referenced in project documentation and provides consistent test data across all examples and tests.

## Testing
- ✅ All references updated consistently
- ✅ No breaking changes - only URL string replacement
- ✅ Tests will use new demo album on next run
- ✅ Documentation examples now point to correct album