### PR TITLE
chore: Remove references to unavailable caption and album name features

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -109,10 +109,12 @@ trmnl-google-photos-plugin/
 
 **Main Templates** (`templates/*.liquid`) are the **source of truth**:
 
-- Use template variables from JSON API (e.g., `{{ photo_url }}`, `{{ caption }}`)
+- Use template variables from JSON API (e.g., `{{ photo_url }}`, `{{ photo_count }}`)
 - Conditionals for handling missing data
 - Error states for unconfigured plugins
 - These are uploaded to TRMNL Markup Editor and used in production
+
+**Note**: `caption` is always `null` and `album_name` is always "Google Photos Shared Album" because these are not available from the Google Photos shared album API.
 
 **Preview Templates** (`templates/preview/*.liquid`) are **synchronized mirrors**:
 
@@ -465,9 +467,9 @@ Use consistent padding unless space constraints require reduction.
 {
   "photo_url": "https://lh3.googleusercontent.com/...",
   "thumbnail_url": "https://lh3.googleusercontent.com/.../w400-h300",
-  "caption": "Beautiful sunset at the beach",
+  "caption": null,
   "timestamp": "2026-01-18T14:00:00Z",
-  "album_name": "Summer Vacation 2026",
+  "album_name": "Google Photos Shared Album",
   "photo_count": 142
 }
 ```
@@ -476,9 +478,9 @@ Use consistent padding unless space constraints require reduction.
 
 - `photo_url` (required): Full-resolution photo URL (optimized for e-ink with size params)
 - `thumbnail_url` (optional): Lower resolution version (not currently used)
-- `caption` (optional): Photo caption/description from Google Photos
+- `caption` (optional): Photo caption/description (**always `null` - not available from API**)
 - `timestamp` (optional): When photo was taken or last updated
-- `album_name` (optional): Name of the source album
+- `album_name` (optional): Name of the source album (**always "Google Photos Shared Album" - actual name not available from API**)
 - `photo_count` (optional): Total photos in album (for display in title bar)
 
 ### Accessing Data in Templates (TRMNL Markup Editor)
@@ -638,7 +640,7 @@ Stateless workflow with Polling strategy:
 2. **TRMNL Polling**: Platform sends GET to `/api/photo?album_url=...` (hourly refresh)
 3. **Fetch Photos**: Worker fetches album data from Google Photos (checks KV cache first)
 4. **Random Selection**: Worker selects random photo from album
-5. **JSON Response**: Worker returns photo data as JSON (photo_url, caption, album_name, etc.)
+5. **JSON Response**: Worker returns photo data as JSON (photo_url, photo_count, timestamp, etc.)
 6. **TRMNL Rendering**: TRMNL platform merges JSON into templates (stored in Markup Editor)
 7. **Display**: TRMNL sends rendered content to device for e-ink display
 8. **No Storage**: No user data persisted, fully stateless

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See how your photos look across different TRMNL layouts:
     <td width="50%" align="center">
       <img src="assets/demo/demo-full.png" alt="Full Layout" width="100%"/>
       <br/><strong>Full Layout</strong>
-      <br/>Full-screen photo with caption
+      <br/>Full-screen photo display
     </td>
     <td width="50%" align="center">
       <img src="assets/demo/demo-half-horizontal.png" alt="Half Horizontal Layout" width="100%"/>
@@ -58,7 +58,7 @@ This plugin is built with privacy at its core:
 - ✅ **Public Albums Only** - Only accesses albums you've explicitly shared
 - ✅ **Direct Access** - Photos load directly from Google's servers to your device
 
-**What's cached?** Only album metadata (photo URLs, captions) for 1 hour. Your actual photos stay on Google's servers and are never stored by us.
+**What's cached?** Only album metadata (photo URLs) for 1 hour. Your actual photos stay on Google's servers and are never stored by us.
 
 Your photos stay private. We simply help your TRMNL display them.
 

--- a/custom-fields.yml
+++ b/custom-fields.yml
@@ -19,8 +19,7 @@
     ⏰ Automatic hourly refresh with new photos<br>
     🎨 Four optimized layouts for all TRMNL device sizes<br>
     📱 Responsive design across all e-ink displays<br>
-    💬 Caption support with smart truncation<br>
-    🏷️ Album name and photo count display
+    🖼️ Photo count display
     <br><br>
     <strong>How It Works:</strong><br>
     1. Create a shared album in Google Photos<br>
@@ -37,7 +36,7 @@
     🎨 Photography portfolios<br>
     💝 Gift displays for loved ones
     <br><br>
-    <strong>Data Privacy:</strong> This plugin prioritizes your privacy. Only album metadata (photo URLs and captions) is temporarily cached for 1 hour to improve performance—your actual photos are never stored and remain on Google's servers. Your album URL is only used to fetch photos in real-time. No cookies, no tracking, no personal data retention. Fully GDPR and privacy compliant.
+    <strong>Data Privacy:</strong> This plugin prioritizes your privacy. Only album metadata (photo URLs) is temporarily cached for 1 hour to improve performance—your actual photos are never stored and remain on Google's servers. Your album URL is only used to fetch photos in real-time. No cookies, no tracking, no personal data retention. Fully GDPR and privacy compliant.
   github_url: https://github.com/hossain-khan/trmnl-google-photos-plugin
   learn_more_url: https://hossain-khan.github.io/trmnl-google-photos-plugin/
   email_address: trmnl@hossain.dev

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -116,14 +116,14 @@ Content-Type: application/json
 
 **Response Fields:**
 
-| Field           | Type           | Description                           |
-| --------------- | -------------- | ------------------------------------- |
-| `photo_url`     | string         | Full-resolution photo URL (optimized) |
-| `thumbnail_url` | string         | Lower resolution version              |
-| `caption`       | string \| null | Photo caption (if available)          |
-| `timestamp`     | string         | ISO 8601 timestamp                    |
-| `album_name`    | string         | Album name                            |
-| `photo_count`   | number         | Total photos in album                 |
+| Field           | Type           | Description                                                                  |
+| --------------- | -------------- | ---------------------------------------------------------------------------- |
+| `photo_url`     | string         | Full-resolution photo URL (optimized)                                        |
+| `thumbnail_url` | string         | Lower resolution version                                                     |
+| `caption`       | string \| null | Photo caption (always `null` - not available from shared albums)             |
+| `timestamp`     | string         | ISO 8601 timestamp                                                           |
+| `album_name`    | string         | Album name (always "Google Photos Shared Album" - actual name not available) |
+| `photo_count`   | number         | Total photos in album                                                        |
 
 **Error: Missing URL (400 Bad Request):**
 


### PR DESCRIPTION
## Summary
Removes references to caption and album name features that are not actually available from the Google Photos shared album API. This ensures we only advertise features that the plugin can actually deliver.

## Problem
The plugin documentation and marketing materials promised:
- ❌ Caption support with smart truncation
- ❌ Album name and photo count display

**Reality**: The `google-photos-album-image-url-fetch` library does not expose captions or album names. These would require additional HTTP requests to parse HTML, adding latency and complexity.

## Changes

### Documentation Updates (4 files)

**1. custom-fields.yml**
- ✅ Removed "Caption support with smart truncation" from Features
- ✅ Removed "Album name and photo count display" from Features  
- ✅ Changed "photo URLs and captions" → "photo URLs" in Data Privacy section
- ✅ Kept "Photo count display" (this actually works!)

**2. README.md**
- ✅ Changed "Full-screen photo with caption" → "Full-screen photo display"
- ✅ Changed "photo URLs, captions" → "photo URLs" in caching section

**3. docs/API_DOCUMENTATION.md**
- ✅ Updated `caption` field: "(always `null` - not available from shared albums)"
- ✅ Updated `album_name` field: "(always \"Google Photos Shared Album\" - actual name not available)"

**4. .github/copilot-instructions.md**
- ✅ Removed example caption "Beautiful sunset at the beach"
- ✅ Removed example album_name "Summer Vacation 2026"  
- ✅ Added clarification note about API limitations
- ✅ Updated JSON examples to show actual values (null, generic names)

## What Still Works

These features remain accurate and functional:
- ✅ Random photo selection from shared albums
- ✅ Photo count display (number of photos in album)
- ✅ Automatic hourly refresh
- ✅ Four optimized layouts for all TRMNL devices
- ✅ Photo URL optimization for e-ink displays
- ✅ KV caching for 80% faster performance

## Technical Details

**Why not parse album name/captions from HTML?**
- Would require additional HTTP request per photo fetch
- Adds 200-500ms latency (defeats our 67ms cache advantage)
- HTML parsing is fragile and could break with Google Photos UI changes
- Not worth the complexity for non-critical metadata

**Current API Response:**
```json
{
  "photo_url": "https://lh3.googleusercontent.com/...",
  "thumbnail_url": "https://lh3.googleusercontent.com/.../w400-h300",
  "caption": null,
  "album_name": "Google Photos Shared Album",
  "photo_count": 142
}
```

## Testing
- ✅ All 217 tests still passing
- ✅ Code formatted with Prettier
- ✅ No functional changes to Worker code
- ✅ Only documentation and marketing copy updated

## Impact
- Better user expectations (only promise what we deliver)
- Simpler codebase (no HTML parsing complexity)
- Faster performance (no extra HTTP requests)
- More honest marketing