### PR TITLE
chore: Add Cloudflare observability configuration

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -11,11 +11,21 @@ workers_dev = true
 [vars]
 ENVIRONMENT = "production"
 
-# Observability - Structured Logging for debugging
-# Note: Using fallback structured logging via console.log (free tier compatible)
-# Analytics Engine is disabled - not available on free plan
-# [[analytics_engine_datasets]]
-# binding = "ANALYTICS"
+# Observability - Logs and Traces for debugging
+[observability]
+enabled = false
+head_sampling_rate = 1
+
+[observability.logs]
+enabled = true
+head_sampling_rate = 1
+persist = true
+invocation_logs = true
+
+[observability.traces]
+enabled = false
+persist = true
+head_sampling_rate = 1
 
 # KV namespace bindings (optional - for caching)
 # Production namespace for caching album photo data (1-hour TTL)


### PR DESCRIPTION
## Summary

Adds Cloudflare Workers observability configuration to `wrangler.toml` to enable structured logging and tracing, ensuring consistency with Cloudflare dashboard settings across all deployments.

## Changes

**Updated `wrangler.toml`:**
- Added `[observability]` configuration block
- Enabled structured logs with persistence and invocation logs
- Configured traces (disabled by default, ready to enable when needed)
- Set `head_sampling_rate = 1` (100% sampling) for comprehensive debugging
- Removed outdated Analytics Engine comments (not available on free tier)

## Configuration Details

```toml
[observability]
enabled = false
head_sampling_rate = 1

[observability.logs]
enabled = true
head_sampling_rate = 1
persist = true
invocation_logs = true

[observability.traces]
enabled = false
persist = true
head_sampling_rate = 1
```

## Benefits

✅ **Centralized Logging**: All Worker logs collected in Cloudflare dashboard  
✅ **Better Debugging**: Persistent logs for troubleshooting production issues  
✅ **Invocation Tracking**: Full request/response logs for performance analysis  
✅ **Deployment Consistency**: Config synced across all deployments via wrangler  
✅ **Free Tier Compatible**: Log persistence included without additional cost  
✅ **Future-Ready**: Traces configured and ready to enable when needed  

## Testing

- [x] Configuration matches Cloudflare dashboard settings
- [x] Deployment succeeds with new observability config
- [x] No breaking changes to existing functionality

## Impact

- **No code changes**: Configuration-only update
- **No performance impact**: Observability runs asynchronously
- **No breaking changes**: Existing deployments continue working
- **Improved monitoring**: Better visibility into Worker behavior and errors

---

This change was made after enabling observability in the Cloudflare dashboard to ensure the configuration is version-controlled and consistent across future deployments.