### PR TITLE
feat: Improve aspect ratio approximation to common ratios

### DIFF
--- a/src/tests/test-fetch.ts
+++ b/src/tests/test-fetch.ts
@@ -215,8 +215,9 @@ describe('Photo Fetcher Helper Functions', () => {
     });
 
     it('should simplify aspect ratio to lowest terms', () => {
-      const result = calculateAspectRatio(1000, 1040); // GCD = 40
-      assert.equal(result, '25:26');
+      // 1000:1040 ≈ 0.96, which is close to 1:1 (1.0) - approximates for better UX
+      const result = calculateAspectRatio(1000, 1040);
+      assert.equal(result, '1:1');
     });
 
     it('should handle different aspect ratios', () => {
@@ -228,6 +229,12 @@ describe('Photo Fetcher Helper Functions', () => {
       assert.equal(calculateAspectRatio(3024, 4032), '3:4'); // iPhone photo (3:4 ratio)
       assert.equal(calculateAspectRatio(4000, 3000), '4:3'); // DSLR landscape (4:3 ratio)
       assert.equal(calculateAspectRatio(2048, 2048), '1:1'); // Instagram square
+    });
+
+    it('should approximate to common ratios within tolerance', () => {
+      // 5694:4075 ≈ 1.397, which is close to 4:3 (1.333) - approximates for better UX
+      const result = calculateAspectRatio(5694, 4075);
+      assert.equal(result, '4:3');
     });
   });
 


### PR DESCRIPTION
## Problem
The aspect ratio calculation was returning mathematically correct but impractical ratios. For example, a photo with dimensions 5694×4075 returned `5694:4075` instead of a more readable common ratio like `4:3`.

## Solution
Implemented tolerance-based matching to common aspect ratios before falling back to GCD simplification:

1. **Common Ratio Matching** (5% tolerance):
   - 1:1 (square)
   - 4:3 (standard)
   - 3:2 (classic photography)
   - 16:10, 5:3, 16:9 (widescreen variants)
   - 2:1, 21:9, 3:1 (ultrawide/panoramic)

2. **Smart Fallback**:
   - Uses GCD simplification for uncommon ratios
   - Decimal approximation for very large simplified ratios

3. **Portrait Support**:
   - Inverts ratios for portrait orientation (e.g., 9:16 instead of 16:9)

## Changes
- Enhanced `calculateAspectRatio()` in [photo-fetcher.ts](../src/services/photo-fetcher.ts)
- Updated tests to reflect new approximation behavior
- Added test case for 5694:4075 → 4:3 approximation

## Benefits
- **Better UX**: `4:3` instead of `5694:4075`
- **More readable**: Common ratios like 16:9, 4:3, 3:2
- **Maintains accuracy**: Only approximates within 5% tolerance
- **Handles edge cases**: Falls back to GCD for uncommon ratios

## Example Improvements
- `5694:4075` (1.397) → `4:3` (1.333) - 4.6% difference ✅
- `1000:1040` (0.96) → `1:1` (1.0) - 4% difference ✅
- `1920:1080` → `16:9` (exact match) ✅

## Test Results
✅ All 262 tests passing  
✅ Bundle size: 836.11 KB (81.7% of 1MB)  
✅ Linter: 0 errors, 0 warnings  
✅ Format: All files formatted

## Resolves
User feedback: "This `5694:4075` ratio looks odd! can we do better like `3:2` in this case?"