### PR TITLE
fix: update demo timestamp to TRMNL OG Kickstarter launch date

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -147,8 +147,8 @@ app.get('/api/photo', async (c) => {
         thumbnail_url:
           'https://hossain-khan.github.io/trmnl-google-photos-plugin/assets/images/google-photos-demo-picture-thumb.jpg',
         caption: 'Demo photo from Google Photos Shared Album TRMNL plugin',
-        timestamp: new Date().toISOString(),
-        album_name: 'Demo Album - Google Photos',
+        timestamp: '2024-06-25T12:00:00.000Z',
+        album_name: 'TRMNL Demo Album - Google Photos',
         photo_count: 142,
       };
 


### PR DESCRIPTION
## Changes

Fixed the demo timestamp to use a consistent, meaningful date.

### Details

- Change demo photo timestamp from dynamic `new Date().toISOString()` to fixed: `2024-06-25T12:00:00.000Z`
- June 25, 2024 represents the TRMNL OG device launch date on Kickstarter
- Ensures consistent demo photo metadata for marketplace preview

### Reference

https://usetrmnl.com/blog/introducing-trmnl-x