### PR TITLE
feat: add on-demand Cloudflare deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,72 @@
+name: Deploy to Cloudflare
+
+# Manual deployment workflow - trigger on-demand via GitHub UI
+# Deploys directly to production (no staging/dev environments configured)
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (validate without deploying)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  deploy:
+    name: Deploy Worker to Cloudflare
+    runs-on: ubuntu-latest
+    
+    # Production deployment only
+    environment:
+      name: production
+      url: https://trmnl-google-photos.gohk.xyz
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Run tests
+        run: npm test
+      
+      - name: TypeScript type check
+        run: npx tsc --noEmit
+      
+      - name: Check code formatting
+        run: npm run format:check
+      
+      - name: Validate Wrangler configuration
+        run: npx wrangler deploy --dry-run --outdir dist
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      
+      # Production deployment
+      - name: Deploy to Cloudflare Workers
+        if: github.event.inputs.dry_run == 'false'
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      
+      # Dry run validation
+      - name: Dry run validation complete
+        if: github.event.inputs.dry_run == 'true'
+        run: |
+          echo "✅ Dry run complete - deployment validated successfully"
+          echo "No changes were deployed to Cloudflare"
+      
+      # Deployment summary
+      - name: Deployment summary
+        if: github.event.inputs.dry_run == 'false'
+        run: |
+          echo "🚀 Deployment complete!"
+          echo "Worker URL: https://trmnl-google-photos.gohk.xyz"
+          echo "API Endpoint: https://trmnl-google-photos.gohk.xyz/api/photo"
+          echo ""


### PR DESCRIPTION
- Add GitHub Actions workflow for manual deployment to Cloudflare Workers
- Production-only deployment (no staging/dev environments)
- Includes dry-run option for validation without deploying
- Pre-deployment checks: tests, type checking, formatting, wrangler validation
- Uses workflow_dispatch for on-demand triggering via GitHub UI

Workflow options:
- Dry run: validate configuration without deploying

Requires CLOUDFLARE_API_TOKEN secret to be configured in GitHub repository settings.