### PR TITLE
chore: Update all TRMNL URLs from usetrmnl.com to trmnl.com

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -165,7 +165,7 @@ trmnl-google-photos-plugin/
 **BYOD Devices** (18+): Kobo, Inkplate, Waveshare, M5Paper, Onyx Boox, and more  
 **Total Supported**: 27+ devices
 
-**Reference**: [Device Models API](https://usetrmnl.com/api/models) • [Photo Fetcher Docs](../src/services/photo-fetcher.ts)
+**Reference**: [Device Models API](https://trmnl.com/api/models) • [Photo Fetcher Docs](../src/services/photo-fetcher.ts)
 
 ### Responsive System
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ All submissions require code review. We'll review:
 - [TypeScript Documentation](https://www.typescriptlang.org/docs/)
 - [Prettier Documentation](https://prettier.io/docs/en/)
 - [ESLint Documentation](https://eslint.org/docs/latest/)
-- [TRMNL Framework](https://usetrmnl.com/docs)
+- [TRMNL Framework](https://trmnl.com/docs)
 
 ## ❓ Questions?
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See how your photos look across different TRMNL layouts:
 </table>
 
 <p align="right">
-  <a href="https://usetrmnl.com/recipes/227153" target="_blank">
+  <a href="https://trmnl.com/recipes/227153" target="_blank">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="assets/trmnl-brand/trmnl-badge-show-it-on-dark.svg">
       <source media="(prefers-color-scheme: light)" srcset="assets/trmnl-brand/trmnl-badge-show-it-on-light.svg">
@@ -93,12 +93,12 @@ Both variants use the same backend API but offer different visual presentations.
 
 ## 📦 Installation
 
-1. Visit [TRMNL Recipes - Google Photos](https://usetrmnl.com/recipes/227153)
+1. Visit [TRMNL Recipes - Google Photos](https://trmnl.com/recipes/227153)
 2. Click **Install** to add the recipe to your TRMNL account
 3. Create a shared album in Google Photos (if you haven't already)
 4. Copy the shared album link from Google Photos
 5. Paste the link in the plugin settings
-6. Add to your [Playlist](https://usetrmnl.com/playlists)
+6. Add to your [Playlist](https://trmnl.com/playlists)
 
 That's it! Your photos will automatically refresh every hour with a new random photo from your album.
 
@@ -149,7 +149,7 @@ MIT License - see [LICENSE](LICENSE) for details
 
 - [`google-photos-album-image-url-fetch`](https://www.npmjs.com/package/google-photos-album-image-url-fetch) The core library that makes fetching Google Photos URLs possible (reverse-engineered API)
 - Inspired by the TRMNL Apple Photos plugin by [@zegl](https://github.com/zegl/trmnl-apple-photos)
-- Built for the amazing [TRMNL](https://usetrmnl.com) community
+- Built for the amazing [TRMNL](https://trmnl.com) community
 
 ---
 

--- a/custom-fields.yml
+++ b/custom-fields.yml
@@ -1,6 +1,6 @@
 # This file contains custom fields for the TRMNL Google Photos Shared Album Plugin
 # Polling Configuration: Uses POST method with JSON body for enhanced privacy
-# Dev Documentation: https://help.usetrmnl.com/en/articles/10513740-custom-plugin-form-builder
+# Dev Documentation: https://help.trmnl.com/en/articles/10513740-custom-plugin-form-builder
 #
 # NOTE: In settings.yml, configure polling as:
 # polling_url: https://trmnl-google-photos.gohk.xyz/api/photo

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -225,7 +225,7 @@ Content-Type: application/json
 
 ```http
 Content-Type: application/json
-Access-Control-Allow-Origin: https://hossain-khan.github.io, https://usetrmnl.com
+Access-Control-Allow-Origin: https://hossain-khan.github.io, https://trmnl.com
 Access-Control-Allow-Methods: GET, OPTIONS
 Access-Control-Max-Age: 86400
 ```
@@ -488,7 +488,7 @@ Same error responses as GET endpoint for invalid URLs, album not found, etc.
 
 ```http
 Content-Type: application/json
-Access-Control-Allow-Origin: https://hossain-khan.github.io, https://usetrmnl.com
+Access-Control-Allow-Origin: https://hossain-khan.github.io, https://trmnl.com
 Access-Control-Allow-Methods: GET, POST, OPTIONS
 Access-Control-Max-Age: 86400
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -881,7 +881,7 @@ The entire system fits in a single Cloudflare Worker (~832KB, 144KB gzipped) and
 - [API Documentation](API_DOCUMENTATION.md) - Complete API reference
 - [Testing Strategy](TESTING.md) - Testing approach and guidelines
 - [Cloudflare Workers Docs](https://developers.cloudflare.com/workers/)
-- [TRMNL Plugin Guide](https://usetrmnl.com/plugins)
+- [TRMNL Plugin Guide](https://trmnl.com/plugins)
 
 ---
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -248,7 +248,7 @@ Content-Security-Policy: default-src 'none'; frame-ancestors 'none'
 ```typescript
 // Allowed origins (whitelist)
 ✅ https://hossain-khan.github.io (GitHub Pages)
-✅ https://usetrmnl.com (TRMNL platform)
+✅ https://trmnl.com (TRMNL platform)
 ✅ http://localhost:8787 (Development)
 ✅ http://localhost:3000 (Development)
 
@@ -429,7 +429,7 @@ For contributors adding new features:
 
 - [OWASP JSON Security Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/AJAX_Security_Cheat_Sheet.html)
 - [Cloudflare Workers Security](https://developers.cloudflare.com/workers/runtime-apis/web-crypto/)
-- [TRMNL Plugin Security Guidelines](https://docs.usetrmnl.com/security)
+- [TRMNL Plugin Security Guidelines](https://docs.trmnl.com/security)
 - [npm audit documentation](https://docs.npmjs.com/cli/v8/commands/npm-audit)
 
 ## License

--- a/docs/SECURITY_REVIEW_SUMMARY.md
+++ b/docs/SECURITY_REVIEW_SUMMARY.md
@@ -130,7 +130,7 @@ Content-Security-Policy: default-src 'none'; frame-ancestors 'none'
 ```typescript
 Allowed Origins:
 ✅ https://hossain-khan.github.io (GitHub Pages)
-✅ https://usetrmnl.com (TRMNL platform)
+✅ https://trmnl.com (TRMNL platform)
 ✅ http://localhost:8787 (Development)
 ✅ http://localhost:3000 (Development)
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://usetrmnl.com/css/latest/plugins.css">
+    <link rel="stylesheet" href="https://trmnl.com/css/latest/plugins.css">
     <link rel="stylesheet" href="assets/www/styles.css">
 </head>
 <body>
@@ -22,7 +22,7 @@
             <span id="statusBadge" class="status-badge status-checking" onclick="checkServiceStatus()" data-tooltip="Click to refresh">🟡 Checking...</span>
         </h1>
         <div style="text-align: center; margin-bottom: 1.5rem;">
-            <a href="https://usetrmnl.com/recipes/227153" target="_blank" style="text-decoration: none;">
+            <a href="https://trmnl.com/recipes/227153" target="_blank" style="text-decoration: none;">
                 <img src="assets/trmnl-brand/trmnl-badge-show-it-on-dark.svg" alt="Show it on TRMNL" style="height: 42px; transition: transform 0.2s ease; cursor: pointer;" onmouseover="this.style.transform='scale(1.05)'" onmouseout="this.style.transform='scale(1)'">
             </a>
         </div>
@@ -98,7 +98,7 @@
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
                 <h2 style="margin: 0;">🚀 Setup Instructions</h2>
                 <div class="badge-container">
-                    <a href="https://usetrmnl.com/recipes/227153" target="_blank" style="text-decoration: none;">
+                    <a href="https://trmnl.com/recipes/227153" target="_blank" style="text-decoration: none;">
                         <img src="assets/trmnl-brand/trmnl-badge-show-it-on-light.svg" 
                              id="showTrmnlBadge"
                              alt="Show it on TRMNL" 
@@ -112,7 +112,7 @@
             <ol>
                 <li>Create a shared album in Google Photos</li>
                 <li>Get the shared album link (photos.app.goo.gl/...)</li>
-                <li><a href="https://usetrmnl.com/recipes/227153" target="_blank">Install the plugin from TRMNL marketplace</a></li>
+                <li><a href="https://trmnl.com/recipes/227153" target="_blank">Install the plugin from TRMNL marketplace</a></li>
                 <li>Paste your shared album URL in the plugin settings</li>
                 <li>Add to your TRMNL playlist</li>
             </ol>

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ app.use(
   cors({
     origin: [
       'https://hossain-khan.github.io',
-      'https://usetrmnl.com',
+      'https://trmnl.com',
       'http://localhost:8787',
       'http://localhost:3000',
     ],
@@ -140,7 +140,7 @@ app.get('/api/photo', async (c) => {
     // Demo Data: If album_url is empty, 'demo', or '0', return demo photo data
     // This allows the plugin to display a preview in the TRMNL marketplace without requiring
     // users to configure their own Google Photos album URL first.
-    // Reference: https://help.usetrmnl.com/en/articles/12772238-demo-data-for-publishing-plugins
+    // Reference: https://help.trmnl.com/en/articles/12772238-demo-data-for-publishing-plugins
     if (
       !album_url ||
       album_url.trim() === '' ||

--- a/src/services/photo-fetcher.ts
+++ b/src/services/photo-fetcher.ts
@@ -95,9 +95,9 @@
  *
  * REFERENCE:
  * ----------------------
- * - TRMNL Framework: https://usetrmnl.com/framework/responsive
- * - Device Models API: https://usetrmnl.com/api/models (source of this data)
- * - Breakpoint Guide: https://usetrmnl.com/framework/responsive#size-based-responsive
+ * - TRMNL Framework: https://trmnl.com/framework/responsive
+ * - Device Models API: https://trmnl.com/api/models (source of this data)
+ * - Breakpoint Guide: https://trmnl.com/framework/responsive#size-based-responsive
  * ====================================================================================
  */
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export interface TRMNLRequest {
        * Device model identifier (e.g., 'v2', 'og_png', 'amazon_kindle_2024')
        * @experimental This property is likely not supported yet by TRMNL platform.
        * @see https://discord.com/channels/1281055965508141100/1284987869546549268/1462580151970959534
-       * @see https://usetrmnl.com/api/models - Device model reference
+       * @see https://trmnl.com/api/models - Device model reference
        */
       device_model_id?: string;
     };

--- a/templates-fullbleed/custom-fields.yml
+++ b/templates-fullbleed/custom-fields.yml
@@ -1,7 +1,7 @@
 # TRMNL Google Photos Canvas Plugin — Custom Fields
 # For distraction-free, fullscreen photo display (no metadata, no captions)
 # Polling Configuration: Uses POST method with JSON body for enhanced privacy
-# Dev Documentation: https://help.usetrmnl.com/en/articles/10513740-custom-plugin-form-builder
+# Dev Documentation: https://help.trmnl.com/en/articles/10513740-custom-plugin-form-builder
 #
 # NOTE: In settings.yml, configure polling as:
 # polling_url: https://trmnl-google-photos.gohk.xyz/api/photo

--- a/templates-fullbleed/shared.liquid
+++ b/templates-fullbleed/shared.liquid
@@ -39,7 +39,7 @@ data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAQAAACQ9RH5AAAAAXNSR0IArs
   - bg--gray-50, bg--gray-55, bg--gray-60, bg--gray-65
   - bg--gray-70, bg--gray-75, bg--white (100% brightness)
   
-  Reference: https://usetrmnl.com/framework/background
+  Reference: https://trmnl.com/framework/background
 {% endcomment %}
 
 {% comment %}

--- a/templates/shared.liquid
+++ b/templates/shared.liquid
@@ -36,7 +36,7 @@ data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADwAAAA8CAQAAACQ9RH5AAAAAXNSR0IArs
   REUSABLE LIQUID TEMPLATES
   ====================================================================================
   These templates follow TRMNL best practices for DRY (Don't Repeat Yourself) code.
-  Reference: https://docs.usetrmnl.com/go/reusing-markup
+  Reference: https://docs.trmnl.com/go/reusing-markup
 {% endcomment %}
 
 {% comment %}


### PR DESCRIPTION
## Summary

Updates all TRMNL domain references from `usetrmnl.com` to `trmnl.com` following TRMNL's official domain migration.

## Changes

### Domain Updates (26 occurrences)
- ✅ `help.usetrmnl.com` → `help.trmnl.com`
- ✅ `docs.usetrmnl.com` → `docs.trmnl.com`
- ✅ `usetrmnl.com/api/*` → `trmnl.com/api/*`
- ✅ `usetrmnl.com/framework/*` → `trmnl.com/framework/*`
- ✅ `usetrmnl.com/recipes/*` → `trmnl.com/recipes/*`

### Files Modified (15 total)

**Configuration Files**:
- `custom-fields.yml`
- `templates-fullbleed/custom-fields.yml`

**Template Files**:
- `templates/shared.liquid`
- `templates-fullbleed/shared.liquid`

**Documentation**:
- `README.md`
- `CONTRIBUTING.md`
- `.github/copilot-instructions.md`

**Docs**:
- `docs/API_DOCUMENTATION.md`
- `docs/ARCHITECTURE.md`
- `docs/SECURITY.md`
- `docs/SECURITY_REVIEW_SUMMARY.md`

**Source Code**:
- `src/index.ts` (CORS origins)
- `src/types.ts`
- `src/services/photo-fetcher.ts`

**Demo**:
- `index.html`

## Testing

✅ No functional changes - all endpoints remain backward compatible  
✅ All existing API integrations continue to work  
✅ Documentation links updated to new domain

## Reference

TRMNL domain migration announcement: https://trmnl.com/blog/trmnl-dot-com

> "if you're a developer building on TRMNL, previous API endpoints should continue working. but we encourage you to switch your base URI to trmnl.com instead of usetrmnl.com."