### PR TITLE
chore: release v1.4.0

### DIFF
--- a/assets/www/script.js
+++ b/assets/www/script.js
@@ -80,7 +80,7 @@ async function checkServiceStatus() {
       badge.textContent = '🟢 Online';
       badge.setAttribute(
         'data-tooltip',
-        `API healthy • ${responseTime}ms • v${data.version || '1.3.0'} • Click to refresh`
+        `API healthy • ${responseTime}ms • v${data.version || '1.4.0'} • Click to refresh`
       );
 
       console.log(`[Status] ✓ Service is healthy (${data.status}) - ${responseTime}ms`);

--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -30,7 +30,7 @@ Host: trmnl-google-photos.gohk.xyz
 {
   "status": "ok",
   "service": "trmnl-google-photos-plugin",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "environment": "production",
   "timestamp": "2026-01-18T20:48:00.000Z",
   "message": "TRMNL Google Photos Plugin is running"
@@ -58,7 +58,7 @@ Host: trmnl-google-photos.gohk.xyz
 {
   "status": "healthy",
   "service": "trmnl-google-photos-plugin",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "environment": "production",
   "timestamp": "2026-01-18T20:48:00.000Z",
   "uptime": "N/A"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -149,7 +149,7 @@ Expected response:
 {
   "status": "ok",
   "service": "trmnl-google-photos-plugin",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "environment": "production",
   "timestamp": "2026-01-18T19:00:00.000Z",
   "message": "TRMNL Google Photos Plugin is running"

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -28,7 +28,7 @@ curl http://localhost:8787/
 # {
 #   "status": "ok",
 #   "service": "trmnl-google-photos-plugin",
-#   "version": "1.3.0",
+#   "version": "1.4.0",
 #   "environment": "production",
 #   "timestamp": "2026-01-19T09:00:00.000Z",
 #   "message": "TRMNL Google Photos Plugin is running"

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -421,6 +421,7 @@ For contributors adding new features:
 
 | Date       | Version | Update                                         |
 | ---------- | ------- | ---------------------------------------------- |
+| 2026-02-27 | 1.4.0   | HTTP 200 error responses with error_type for TRMNL template injection |
 | 2026-02-02 | 1.3.0   | POST /api/photo endpoint (privacy enhancement) |
 | 2026-02-02 | 1.2.0   | Smart photo selection (duplicate prevention)   |
 | 2026-01-24 | 1.1.0   | Adaptive background brightness analysis        |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -419,12 +419,12 @@ For contributors adding new features:
 
 ## Security Updates
 
-| Date       | Version | Update                                         |
-| ---------- | ------- | ---------------------------------------------- |
+| Date       | Version | Update                                                                |
+| ---------- | ------- | --------------------------------------------------------------------- |
 | 2026-02-27 | 1.4.0   | HTTP 200 error responses with error_type for TRMNL template injection |
-| 2026-02-02 | 1.3.0   | POST /api/photo endpoint (privacy enhancement) |
-| 2026-02-02 | 1.2.0   | Smart photo selection (duplicate prevention)   |
-| 2026-01-24 | 1.1.0   | Adaptive background brightness analysis        |
+| 2026-02-02 | 1.3.0   | POST /api/photo endpoint (privacy enhancement)                        |
+| 2026-02-02 | 1.2.0   | Smart photo selection (duplicate prevention)                          |
+| 2026-01-24 | 1.1.0   | Adaptive background brightness analysis                               |
 
 ## References
 

--- a/docs/SECURITY_REVIEW_SUMMARY.md
+++ b/docs/SECURITY_REVIEW_SUMMARY.md
@@ -1,7 +1,7 @@
 # Security Review Summary - JSON API
 
 **Date**: January 19, 2026  
-**Version**: 1.3.0  
+**Version**: 1.4.0  
 **Reviewer**: GitHub Copilot (AI Security Review)  
 **Status**: ✅ **PASSED - Ready for Production**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trmnl-google-photos-plugin",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trmnl-google-photos-plugin",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trmnl-google-photos-plugin",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "TRMNL plugin for displaying random photos from Google Photos shared albums",
   "main": "src/scripts/fetch-photos.js",
   "type": "module",


### PR DESCRIPTION
## Release v1.4.0

Version bump from `1.3.0` → `1.4.0`.

### What's included in this release

This release corresponds to the fix in PR #167 — improved error handling so the TRMNL device displays the correct message when a user's Google Photos shared album is deleted or made private.

### Version updated in

| File | Change |
|---|---|
| `package.json` | `1.3.0` → `1.4.0` |
| `package-lock.json` | project entries `1.3.0` → `1.4.0` |
| `assets/www/script.js` | fallback version string `1.3.0` → `1.4.0` |
| `docs/QUICKSTART.md` | example response `1.3.0` → `1.4.0` |
| `docs/DEPLOYMENT.md` | example response `1.3.0` → `1.4.0` |
| `docs/API_DOCUMENTATION.md` | two example responses `1.3.0` → `1.4.0` |
| `docs/SECURITY_REVIEW_SUMMARY.md` | version header `1.3.0` → `1.4.0` |
| `docs/SECURITY.md` | added `1.4.0` changelog entry (history preserved) |

### CI

- ✅ `eslint` — 43 warnings, 0 errors (under 50 max threshold)
- ✅ `prettier` — all files formatted correctly
- ✅ `npm test` — 355/355 tests pass